### PR TITLE
去重处理，避免一个播放源多集显示

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -309,7 +309,8 @@ async function handleSpecialSourceDetail(id, sourceCode) {
             const generalPattern = /\$(https?:\/\/[^"'\s]+?\.m3u8)/g;
             matches = html.match(generalPattern) || [];
         }
-        
+        // 去重处理，避免一个播放源多集显示
+        matches = [...new Set(matches)];
         // 处理链接
         matches = matches.map(link => {
             link = link.substring(1, link.length);


### PR DESCRIPTION
非凡资源视频每集会变成三集，也就是40集的电视剧会变成120集，每3集内容一样。
这里添加一段代码对非凡资源链接去重。