### PR TITLE
修复与优化：历史记录卡片播放进度实时同步

### DIFF
--- a/player.html
+++ b/player.html
@@ -329,6 +329,33 @@
 
             // 添加页面离开事件监听，保存播放位置
             window.addEventListener('beforeunload', saveCurrentProgress);
+
+            // 新增：页面隐藏（切后台/切标签）时也保存
+            document.addEventListener('visibilitychange', function() {
+                if (document.visibilityState === 'hidden') {
+                    saveCurrentProgress();
+                }
+            });
+
+            // 新增：视频暂停时也保存
+            // 需确保 dp.video 已初始化
+            const waitForVideo = setInterval(() => {
+                if (dp && dp.video) {
+                    dp.video.addEventListener('pause', saveCurrentProgress);
+
+                    // 新增：播放进度变化时节流保存
+                    let lastSave = 0;
+                    dp.video.addEventListener('timeupdate', function() {
+                        const now = Date.now();
+                        if (now - lastSave > 5000) { // 每5秒最多保存一次
+                            saveCurrentProgress();
+                            lastSave = now;
+                        }
+                    });
+
+                    clearInterval(waitForVideo);
+                }
+            }, 200);
         });
 
         // 处理键盘快捷键
@@ -1131,14 +1158,11 @@
         
         // 保存当前播放进度
         function saveCurrentProgress() {
-            if (!dp || !dp.video || dp.video.paused || videoHasEnded) return;
-            
-            // 如果播放进度太短或接近结尾，不保存
+            if (!dp || !dp.video) return;
             const currentTime = dp.video.currentTime;
             const duration = dp.video.duration;
-            
-            if (currentTime < 10 || currentTime > duration * 0.95) return;
-            
+            if (!duration || currentTime < 1) return;
+
             // 在localStorage中保存进度
             const progressKey = `videoProgress_${getVideoId()}`;
             const progressData = {
@@ -1146,10 +1170,34 @@
                 duration: duration,
                 timestamp: Date.now()
             };
-            
             try {
                 localStorage.setItem(progressKey, JSON.stringify(progressData));
-                console.log(`已保存播放进度: ${formatTime(currentTime)} / ${formatTime(duration)}`);
+                // --- 新增：同步更新 viewingHistory 中的进度 ---
+                try {
+                    const historyRaw = localStorage.getItem('viewingHistory');
+                    if (historyRaw) {
+                        const history = JSON.parse(historyRaw);
+                        // 用 title + 集数索引唯一标识
+                        const idx = history.findIndex(item =>
+                            item.title === currentVideoTitle &&
+                            (item.episodeIndex === undefined || item.episodeIndex === currentEpisodeIndex)
+                        );
+                        if (idx !== -1) {
+                            // 只在进度有明显变化时才更新，减少写入
+                            if (
+                                Math.abs((history[idx].playbackPosition || 0) - currentTime) > 2 ||
+                                Math.abs((history[idx].duration || 0) - duration) > 2
+                            ) {
+                                history[idx].playbackPosition = currentTime;
+                                history[idx].duration = duration;
+                                history[idx].timestamp = Date.now();
+                                localStorage.setItem('viewingHistory', JSON.stringify(history));
+                            }
+                        }
+                    }
+                } catch (e) {
+                    // 忽略 viewingHistory 更新错误
+                }
             } catch (e) {
                 console.error('保存播放进度失败', e);
             }


### PR DESCRIPTION
修复了历史记录卡片中播放进度信息不实时更新的问题。
现在每当播放进度自动保存（如定时、暂停、切后台、切集数等场景）时，会同步更新 viewingHistory 中对应视频/集数的 playbackPosition 和 duration 字段。 这样在侧栏历史记录中可以实时看到最新的播放进度，无需重新加载或切换视频。
优化了写入逻辑，仅在进度有明显变化（2秒以上）时才更新，减少 localStorage 写入频率。
进一步提升了播放进度记录的稳定性和用户体验。