### PR TITLE
feat: 增加Docker部署的内置代理支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM nginx:alpine
+FROM fabiocicerchia/nginx-lua:1.27.5-alpine3.21.3
 LABEL maintainer="LibreTV Team"
 LABEL description="LibreTV - 免费在线视频搜索与观看平台"
 
 # 复制应用文件
 COPY . /usr/share/nginx/html
+
+# 复制Nginx配置文件
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # 添加执行权限并设置为入口点脚本
 COPY docker-entrypoint.sh /

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,86 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    resolver 114.114.114.114 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+
+    # 创建代理路由
+    location /proxy/ {
+        # 设置CORS头部
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+
+        # OPTIONS请求处理
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+
+        set $target_url '';
+
+        # 执行Lua脚本解析URL
+        rewrite_by_lua_file /usr/share/nginx/html/proxy.lua;
+
+        proxy_ssl_server_name on;
+        proxy_ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+
+        # 设置代理头信息
+        # 不设置Host，让Nginx自动根据目标URL设置
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # 处理可能的重定向
+        proxy_redirect off;
+        proxy_buffering off;
+        # 代理超时设置
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
+        proxy_pass $target_url;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/proxy.lua
+++ b/proxy.lua
@@ -1,0 +1,38 @@
+-- 解码URL函数
+local function decode_uri(uri)
+    local decoded = ngx.unescape_uri(uri)
+    return decoded
+end
+
+-- 直接从请求URI获取完整URL
+local request_uri = ngx.var.request_uri
+ngx.log(ngx.DEBUG, "完整请求URI: ", request_uri)
+
+-- 提取/proxy/后面的部分
+local _, _, target_path = string.find(request_uri, "^/proxy/(.*)")
+ngx.log(ngx.DEBUG, "提取的目标路径: ", target_path or "nil")
+
+if not target_path or target_path == "" then
+    ngx.status = 400
+    ngx.say("错误: 未提供目标URL")
+    return ngx.exit(400)
+end
+
+-- 解码URL
+local target_url = decode_uri(target_path)
+ngx.log(ngx.DEBUG, "解码后的目标URL: ", target_url)
+
+if not target_url or target_url == "" then
+    ngx.status = 400
+    ngx.say("错误: 无法解析目标URL")
+    return ngx.exit(400)
+end
+
+-- 记录日志
+ngx.log(ngx.STDERR, "代理请求: ", target_url)
+
+-- 设置目标URL变量供Nginx使用
+ngx.var.target_url = target_url
+
+-- 继续执行Nginx配置的其余部分
+return


### PR DESCRIPTION
使用Nginx-lua扩展实现内部代理，解决Docker部署下的API跨域问题。

由于将基础镜像改为`fabiocicerchia/nginx-lua:1.27.5-alpine3.21.3`，镜像大小将由49MB增加至95MB

#131 