### PR TITLE
预加载集数

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -172,6 +172,18 @@ const PLAYER_CONFIG = {
     adFilteringStorage: 'adFilteringEnabled' // 存储广告过滤设置的键名
 };
 
+
+// ==== LibreTV: 预加载功能与调试日志开关 ====
+
+// 挂到window上，供全局/其它文件使用
+window.PLAYER_CONFIG = PLAYER_CONFIG;
+
+// 是否启用播放器多集预加载功能（见player.html微调）。如需关闭，设为 false
+window.PLAYER_CONFIG.enablePreloading = true;  // 可根据需要设为 false
+
+// 是否启用详细调试日志（推荐测试/定位问题时启用）。如需关闭，设为 false 或删除此行
+window.PLAYER_CONFIG.debugMode = false;         // 或 false/留空关闭详细日志
+
 // 增加错误信息本地化
 const ERROR_MESSAGES = {
     NETWORK_ERROR: '网络连接错误，请检查网络设置',

--- a/player.html
+++ b/player.html
@@ -1399,5 +1399,207 @@
                 : '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d=\"M15 11V7a3 3 0 00-6 0v4m-3 4h12v6H6v-6z\"/>';
         }
     </script>
+
+<script>
+/**
+ * 优化后的集数预加载功能（自动兼容window作用域和多次切集数）
+ * - 集成到player.html和全局
+ * - 优化事件&变量同步
+ * - 日志更友好调试
+ */
+(function(){
+    const PRELOAD_EPISODE_COUNT = 2;
+
+    // 兼容性检测
+    function supportsCacheStorage() {
+        return 'caches' in window && window.caches.open;
+    }
+
+    function isSlowNetwork() {
+        try {
+            const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+            return conn && conn.effectiveType && /2g|slow-2g/i.test(conn.effectiveType);
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * 自动同步局部变量到window，防止作用域bug
+     */
+    function syncGlobalEpisodes() {
+        if (typeof currentEpisodes !== "undefined") window.currentEpisodes = currentEpisodes;
+        if (typeof currentEpisodeIndex !== "undefined") window.currentEpisodeIndex = currentEpisodeIndex;
+    }
+
+    /**
+     * 预加载下N集（m3u8和前3个ts分片）
+     */
+    async function preloadNextEpisodeParts(preloadCount = PRELOAD_EPISODE_COUNT) {
+        // 检查开关
+        if (!(window.PLAYER_CONFIG && PLAYER_CONFIG.enablePreloading)) return;
+        if (isSlowNetwork()) {
+            if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode) console.log('[Preload] 跳过，网络过慢');
+            return;
+        }
+
+        // 确保有全局数据（后端逻辑已在player.html同步!）
+        syncGlobalEpisodes();
+        if (!window.currentEpisodes || !Array.isArray(window.currentEpisodes) || typeof window.currentEpisodeIndex !== 'number') {
+            if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode) console.log('[Preload] 跳过，集数或索引缺失');
+            return;
+        }
+
+        const idx = window.currentEpisodeIndex, maxIndex = window.currentEpisodes.length - 1;
+        if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+            console.log(`[Preload] 尝试预加载第${idx+1}~${Math.min(idx+preloadCount, maxIndex)+1}集`);
+
+        for (let offset = 1; offset <= preloadCount; offset++) {
+            const episodeIdx = idx + offset;
+            if (episodeIdx > maxIndex) break;
+            const nextUrl = window.currentEpisodes[episodeIdx];
+
+            if (!nextUrl || typeof nextUrl !== 'string') {
+                if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                    console.log(`[Preload] 略过空URL@${episodeIdx}`);
+                continue;
+            }
+            try {
+                const m3u8Resp = await fetch(nextUrl, { method: "GET", credentials: "same-origin" });
+                if (!m3u8Resp.ok) {
+                    if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                        console.log(`[Preload] m3u8请求失败: ${nextUrl}`);
+                    continue;
+                }
+                const m3u8Text = await m3u8Resp.text();
+                const tsUrls = [];
+                const base = nextUrl.substring(0, nextUrl.lastIndexOf('/') + 1);
+                m3u8Text.split('\n').forEach(line => {
+                    const t = line.trim();
+                    if (t && !t.startsWith("#") && /\.ts(\?|$)/i.test(t) && tsUrls.length < 3) {
+                        tsUrls.push(/^https?:\/\//i.test(t) ? t : base + t);
+                    }
+                });
+
+                if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                    console.log(`[Preload] m3u8分析结果: ts分片=${tsUrls.length}, ep${episodeIdx+1} ${nextUrl}`);
+
+                for (const tsUrl of tsUrls) {
+                    if (supportsCacheStorage()) {
+                        try {
+                            const cache = await caches.open('libretv-preload1');
+                            const cachedResp = await cache.match(tsUrl);
+                            if (!cachedResp) {
+                                const resp = await fetch(tsUrl, { method: "GET", credentials: "same-origin" });
+                                if (resp.ok) {
+                                    await cache.put(tsUrl, resp.clone());
+                                    if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                                        console.log(`[Preload] ts已缓存: ${tsUrl}`);
+                                } else if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode) {
+                                    console.log(`[Preload] ts拉取失败: ${tsUrl}`);
+                                }
+                            } else {
+                                if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                                    console.log(`[Preload] ts已存在缓存: ${tsUrl}`);
+                            }
+                        } catch (ex) {
+                            if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                                console.log(`[Preload] ts缓存失败: ${tsUrl}, e=${ex}`);
+                        }
+                    } else {
+                        // fallback fetch (非缓存环境也拉一下)
+                        try {
+                            const resp = await fetch(tsUrl, { method: "GET", credentials: "same-origin" });
+                            if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode) {
+                                if (resp.ok) console.log(`[Preload] ts已拉取(非缓存): ${tsUrl}`);
+                                else console.log(`[Preload] ts拉取失败: ${tsUrl}`);
+                            }
+                        } catch (ex) {
+                            if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                                console.log(`[Preload] ts拉取异常(非缓存): ${tsUrl} e=${ex}`);
+                        }
+                    }
+                }
+            } catch (e) {
+                if (window.PLAYER_CONFIG && PLAYER_CONFIG.debugMode)
+                    console.log(`[Preload] m3u8拉取异常: ${nextUrl}; e=${e}`);
+            }
+        }
+    }
+    // 挂到window
+    window.preloadNextEpisodeParts = preloadNextEpisodeParts;
+
+    // 事件注册优化：只有当数据可用时才注册
+    function safeRegisterPreloadEvents() {
+        syncGlobalEpisodes();
+        if (!(window.PLAYER_CONFIG && PLAYER_CONFIG.enablePreloading)) return;
+        if (!window.currentEpisodes || !Array.isArray(window.currentEpisodes) || typeof window.currentEpisodeIndex !== 'number') {
+            // 数据未准备，稍后再试
+            setTimeout(safeRegisterPreloadEvents, 300);
+            return;
+        }
+        // 下一集按钮悬停、触摸预加载
+        const nextBtn = document.getElementById('nextButton');
+        if (nextBtn && !nextBtn._preloadHooked) {
+            nextBtn._preloadHooked = true;
+            nextBtn.addEventListener('mouseenter', () => preloadNextEpisodeParts(PRELOAD_EPISODE_COUNT), {passive:true});
+            nextBtn.addEventListener('touchstart', () => preloadNextEpisodeParts(PRELOAD_EPISODE_COUNT), {passive:true});
+        }
+        // 播放接近结尾时预加载
+        function setupTimeupdatePreload() {
+            if (window.dp && window.dp.video && typeof window.dp.video.addEventListener === 'function' && !window.dp._preloadHooked) {
+                window.dp._preloadHooked = true;
+                window.dp.video.addEventListener('timeupdate', function() {
+                    if (window.dp.video.duration &&
+                        window.dp.video.currentTime > window.dp.video.duration - 12) {
+                        preloadNextEpisodeParts(PRELOAD_EPISODE_COUNT);
+                    }
+                });
+            }
+        }
+        // 确保 dp 可用再注册
+        if (window.dp && window.dp.video) setupTimeupdatePreload();
+        else {
+            let tries = 0;
+            const timer = setInterval(() => {
+                if (window.dp && window.dp.video) {
+                    setupTimeupdatePreload();
+                    clearInterval(timer);
+                }
+                if (++tries > 50) clearInterval(timer);
+            }, 200);
+        }
+        // Any 集数点击后预加载
+        const episodesList = document.getElementById('episodesList');
+        if (episodesList && !episodesList._preloadHooked) {
+            episodesList._preloadHooked = true;
+            episodesList.addEventListener('click', function(e){
+                const btn = e.target.closest('button[id^="episode-"]');
+                if (btn) setTimeout(() => preloadNextEpisodeParts(PRELOAD_EPISODE_COUNT), 200);
+            });
+        }
+    }
+
+    // 数据同步后挂载事件
+    document.addEventListener('DOMContentLoaded', ()=>{
+        syncGlobalEpisodes();
+        // 首次注册
+        safeRegisterPreloadEvents();
+        // 集数切换时重新同步全局变量并尝试预加载
+        // （注意：playEpisode 函数调用后同步全局即可）
+        const origPlayEpisode = window.playEpisode;
+        if (typeof origPlayEpisode === 'function') {
+            window.playEpisode = function(idx){
+                if (typeof currentEpisodes !== "undefined") window.currentEpisodes = currentEpisodes;
+                if (typeof currentEpisodeIndex !== "undefined") window.currentEpisodeIndex = currentEpisodeIndex;
+                origPlayEpisode(idx);
+                // 仅播放后才触发，防止误预加载
+                setTimeout(()=>preloadNextEpisodeParts(PRELOAD_EPISODE_COUNT), 250);
+            }
+        }
+    });
+})();
+</script>
+    
 </body>
 </html>

--- a/player.html
+++ b/player.html
@@ -1408,7 +1408,7 @@
  * - 日志更友好调试
  */
 (function(){
-    const PRELOAD_EPISODE_COUNT = 2;
+    const PRELOAD_EPISODE_COUNT = 2; //自定义拉取下面的多少集数
 
     // 兼容性检测
     function supportsCacheStorage() {


### PR DESCRIPTION
**1. 功能目的**

这段预加载代码专为 视频多集连续播放场景优化，目的是：

    当用户即将切换集数或即将看完当前一集时或单击集数时，提前后台加载下一集的 m3u8 文件和前几个 ts 分片（视频片段），
    这样用户点击“下一集”或自动连播时，可以极快加载视频、几乎无缓冲等待，实现“极致快切”体验。

**2. 主要特性**

    **自动识别网络状况:** 在网络极慢（2g/slow-2g）时自动跳过预加载，避免浪费流量和资源。

    **缓存优先**
    支持浏览器 CacheStorage。（支持时优先缓存，每次只拉队列前3个 ts 分片且保存；如不支持则普通 fetch，依然保证不卡顿。）
    
**多种触发时机**
```
        鼠标悬停或触摸“下一集”按钮时；
        正在播放时、如果到了快结尾（倒数12秒）；
        手动切换任意集数按钮后； 

三种场景都能自动执行预加载。比如单击第5集，按player.html里面的设置，默认2，所以会同时拉取 6和7的前3片。
在config.js开启日志后，就可以在浏览器控制台看见详细的preload日志
```

3、 config.js 配置 预加载开关

```
// 是否启用播放器多集预加载功能（见player.html微调）。如需关闭，设为 false
window.PLAYER_CONFIG.enablePreloading = true;  

// 是否启用详细调试日志（推荐测试/定位问题时启用）。如需关闭，设为 false 或删除此行
window.PLAYER_CONFIG.debugMode = false;    
```