### PR TITLE
优化广告过滤逻辑，解决最后一个分片无法播放的问题

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -880,7 +880,7 @@ async function showDetails(id, vod_name, sourceCode) {
 }
 
 // 更新播放视频函数，修改为在新标签页中打开播放页面，并保存到历史记录
-function playVideo(url, vod_name, episodeIndex = 0, sourceCode) {
+function playVideo(url, vod_name, sourceCode, episodeIndex = 0) {
     // 密码保护校验
     if (window.isPasswordProtected && window.isPasswordVerified) {
         if (window.isPasswordProtected() && !window.isPasswordVerified()) {
@@ -944,7 +944,7 @@ function playPreviousEpisode(sourceCode) {
     if (currentEpisodeIndex > 0) {
         const prevIndex = currentEpisodeIndex - 1;
         const prevUrl = currentEpisodes[prevIndex];
-        playVideo(prevUrl, currentVideoTitle, prevIndex, sourceCode);
+        playVideo(prevUrl, currentVideoTitle, sourceCode, prevIndex);
     }
 }
 
@@ -953,7 +953,7 @@ function playNextEpisode(sourceCode) {
     if (currentEpisodeIndex < currentEpisodes.length - 1) {
         const nextIndex = currentEpisodeIndex + 1;
         const nextUrl = currentEpisodes[nextIndex];
-        playVideo(nextUrl, currentVideoTitle, nextIndex, sourceCode);
+        playVideo(nextUrl, currentVideoTitle, sourceCode, nextIndex);
     }
 }
 
@@ -970,7 +970,7 @@ function renderEpisodes(vodName, sourceCode) {
         // 根据倒序状态计算真实的剧集索引
         const realIndex = episodesReversed ? currentEpisodes.length - 1 - index : index;
         return `
-            <button id="episode-${realIndex}" onclick="playVideo('${episode}','${vodName.replace(/"/g, '&quot;')}', ${realIndex}, ${sourceCode})" 
+            <button id="episode-${realIndex}" onclick="playVideo('${episode}','${vodName.replace(/"/g, '&quot;')}', ${sourceCode}, ${realIndex})" 
                     class="px-4 py-2 bg-[#222] hover:bg-[#333] border border-[#333] rounded-lg transition-colors text-center episode-btn">
                 第${realIndex + 1}集
             </button>

--- a/js/app.js
+++ b/js/app.js
@@ -970,7 +970,7 @@ function renderEpisodes(vodName, sourceCode) {
         // 根据倒序状态计算真实的剧集索引
         const realIndex = episodesReversed ? currentEpisodes.length - 1 - index : index;
         return `
-            <button id="episode-${realIndex}" onclick="playVideo('${episode}','${vodName.replace(/"/g, '&quot;')}', ${sourceCode}, ${realIndex})" 
+            <button id="episode-${realIndex}" onclick="playVideo('${episode}','${vodName.replace(/"/g, '&quot;')}', '${sourceCode}', ${realIndex})" 
                     class="px-4 py-2 bg-[#222] hover:bg-[#333] border border-[#333] rounded-lg transition-colors text-center episode-btn">
                 第${realIndex + 1}集
             </button>

--- a/js/app.js
+++ b/js/app.js
@@ -855,7 +855,7 @@ async function showDetails(id, vod_name, sourceCode) {
             episodesReversed = false; // 默认正序
             modalContent.innerHTML = `
                 <div class="flex justify-end mb-2">
-                    <button onclick="toggleEpisodeOrder()" class="px-4 py-2 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white font-semibold rounded-full shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 flex items-center justify-center space-x-2">
+                    <button onclick="toggleEpisodeOrder(${sourceCode})" class="px-4 py-2 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white font-semibold rounded-full shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 flex items-center justify-center space-x-2">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clip-rule="evenodd" />
                         </svg>
@@ -863,7 +863,7 @@ async function showDetails(id, vod_name, sourceCode) {
                     </button>
                 </div>
                 <div id="episodesGrid" class="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2">
-                    ${renderEpisodes(vod_name)}
+                    ${renderEpisodes(vod_name, sourceCode)}
                 </div>
             `;
         } else {
@@ -880,7 +880,7 @@ async function showDetails(id, vod_name, sourceCode) {
 }
 
 // 更新播放视频函数，修改为在新标签页中打开播放页面，并保存到历史记录
-function playVideo(url, vod_name, episodeIndex = 0) {
+function playVideo(url, vod_name, episodeIndex = 0, sourceCode) {
     // 密码保护校验
     if (window.isPasswordProtected && window.isPasswordVerified) {
         if (window.isPasswordProtected() && !window.isPasswordVerified()) {
@@ -933,27 +933,27 @@ function playVideo(url, vod_name, episodeIndex = 0) {
     }
     
     // 构建播放页面URL，传递必要参数
-    const playerUrl = `player.html?url=${encodeURIComponent(url)}&title=${encodeURIComponent(videoTitle)}&index=${episodeIndex}&source=${encodeURIComponent(sourceName)}`;
+    const playerUrl = `player.html?url=${encodeURIComponent(url)}&title=${encodeURIComponent(videoTitle)}&index=${episodeIndex}&source=${encodeURIComponent(sourceName)}&source_code=${encodeURIComponent(sourceCode)}`;
     
     // 在新标签页中打开播放页面
     window.open(playerUrl, '_blank');
 }
 
 // 播放上一集
-function playPreviousEpisode() {
+function playPreviousEpisode(sourceCode) {
     if (currentEpisodeIndex > 0) {
         const prevIndex = currentEpisodeIndex - 1;
         const prevUrl = currentEpisodes[prevIndex];
-        playVideo(prevUrl, currentVideoTitle, prevIndex);
+        playVideo(prevUrl, currentVideoTitle, prevIndex, sourceCode);
     }
 }
 
 // 播放下一集
-function playNextEpisode() {
+function playNextEpisode(sourceCode) {
     if (currentEpisodeIndex < currentEpisodes.length - 1) {
         const nextIndex = currentEpisodeIndex + 1;
         const nextUrl = currentEpisodes[nextIndex];
-        playVideo(nextUrl, currentVideoTitle, nextIndex);
+        playVideo(nextUrl, currentVideoTitle, nextIndex, sourceCode);
     }
 }
 
@@ -964,13 +964,13 @@ function handlePlayerError() {
 }
 
 // 辅助函数用于渲染剧集按钮（使用当前的排序状态）
-function renderEpisodes(vodName) {
+function renderEpisodes(vodName, sourceCode) {
     const episodes = episodesReversed ? [...currentEpisodes].reverse() : currentEpisodes;
     return episodes.map((episode, index) => {
         // 根据倒序状态计算真实的剧集索引
         const realIndex = episodesReversed ? currentEpisodes.length - 1 - index : index;
         return `
-            <button id="episode-${realIndex}" onclick="playVideo('${episode}','${vodName.replace(/"/g, '&quot;')}', ${realIndex})" 
+            <button id="episode-${realIndex}" onclick="playVideo('${episode}','${vodName.replace(/"/g, '&quot;')}', ${realIndex}, ${sourceCode})" 
                     class="px-4 py-2 bg-[#222] hover:bg-[#333] border border-[#333] rounded-lg transition-colors text-center episode-btn">
                 第${realIndex + 1}集
             </button>
@@ -979,16 +979,16 @@ function renderEpisodes(vodName) {
 }
 
 // 切换排序状态的函数
-function toggleEpisodeOrder() {
+function toggleEpisodeOrder(sourceCode) {
     episodesReversed = !episodesReversed;
     // 重新渲染剧集区域，使用 currentVideoTitle 作为视频标题
     const episodesGrid = document.getElementById('episodesGrid');
     if (episodesGrid) {
-        episodesGrid.innerHTML = renderEpisodes(currentVideoTitle);
+        episodesGrid.innerHTML = renderEpisodes(currentVideoTitle, sourceCode);
     }
     
     // 更新按钮文本和箭头方向
-    const toggleBtn = document.querySelector('button[onclick="toggleEpisodeOrder()"]');
+    const toggleBtn = document.querySelector(`button[onclick="toggleEpisodeOrder(${sourceCode})"]`);
     if (toggleBtn) {
         toggleBtn.querySelector('span').textContent = episodesReversed ? '正序排列' : '倒序排列';
         const arrowIcon = toggleBtn.querySelector('svg');

--- a/js/config.js
+++ b/js/config.js
@@ -24,12 +24,14 @@ const API_SITES = {
     heimuer: {
         api: 'https://json.heimuer.xyz',
         name: '黑木耳',
-        detail: 'https://heimuer.tv'
+        detail: 'https://heimuer.tv',
+        filterAdRule: '#EXT-X-DISCONTINUITY\\n#EXTINF:\\d+\\.\\d+,\\n.*?\\n#EXT-X-DISCONTINUITY'
     },
     ffzy: {
         api: 'http://ffzy5.tv',
         name: '非凡影视',
-        detail: 'http://ffzy5.tv'
+        detail: 'http://ffzy5.tv',
+        filterAdRule: '#EXT-X-DISCONTINUITY[\\r\\n]+(?:#EXTINF:\\d+\\.\\d{6},[\\r\\n]+.*?[\\r\\n]+){4,5}#EXT-X-DISCONTINUITY'
     },
     tyyszy: {
         api: 'https://tyyszy.com',
@@ -76,12 +78,10 @@ const API_SITES = {
     mdzy: {
         api: 'https://www.mdzyapi.com',
         name: '魔都资源',
-        filterAd: false,
     },
     ruyi: {
         api: 'https://cj.rycjapi.com',
         name: '如意资源',
-        filterAd: false,
     },
     jkun: {
         api: 'https://jkunzyapi.com',

--- a/js/config.js
+++ b/js/config.js
@@ -76,10 +76,12 @@ const API_SITES = {
     mdzy: {
         api: 'https://www.mdzyapi.com',
         name: '魔都资源',
+        filterAd: false,
     },
     ruyi: {
         api: 'https://cj.rycjapi.com',
         name: '如意资源',
+        filterAd: false,
     },
     jkun: {
         api: 'https://jkunzyapi.com',

--- a/js/config.js
+++ b/js/config.js
@@ -31,7 +31,7 @@ const API_SITES = {
         api: 'http://ffzy5.tv',
         name: '非凡影视',
         detail: 'http://ffzy5.tv',
-        filterAdRule: '#EXT-X-DISCONTINUITY[\\r\\n]+(?:#EXTINF:\\d+\\.\\d{6},[\\r\\n]+.*?[\\r\\n]+){4,5}#EXT-X-DISCONTINUITY'
+        filterAdRule: '#EXT-X-DISCONTINUITY\\r*\\n*#EXTINF:6.666667,[\\s\\S]*?#EXT-X-DISCONTINUITY'
     },
     tyyszy: {
         api: 'https://tyyszy.com',

--- a/player.html
+++ b/player.html
@@ -525,10 +525,12 @@
         function initPlayer(videoUrl, sourceCode) {
             if (!videoUrl) return;
 
+            window.filterAdPattern = API_SITES[sourceCode].filterAdRule
+
             // 配置HLS.js选项
             const hlsConfig = {
                 debug: false,
-                loader: (adFilteringEnabled && API_SITES[sourceCode].filterAd !== false) ? CustomHlsJsLoader : Hls.DefaultConfig.loader,
+                loader: (adFilteringEnabled && API_SITES[sourceCode].filterAdRule) ? CustomHlsJsLoader : Hls.DefaultConfig.loader,
                 enableWorker: true,
                 lowLatencyMode: false,
                 backBufferLength: 90,
@@ -874,67 +876,9 @@
         function filterAdsFromM3U8(m3u8Content, strictMode = false) {
             if (!m3u8Content) return '';
 
-            let skipContent = false;
-            let discontinuityCount = 0;
-            let currentSegmentDuration = 0;
-            let totalOriginalDuration = 0;
-            let totalFilteredDuration = 0;
-            let afterSegmentUrl = false
-                
-            // 按行分割M3U8内容
-            const lines = m3u8Content.split('\n');
-            const filteredLines = [];
-                
-            for (let i = 0; i < lines.length; i++) {
-                const line = lines[i].trim();
-
-                if (line.includes('#EXT-X-DISCONTINUITY')) {
-                    discontinuityCount++;
-                    if (afterSegmentUrl) {
-                        // 在视频 url 前可能会出现 DISCONTINUITY 的情况，忽略
-                        skipContent = !skipContent;
-                    }
-                    continue;
-                }
-
-                if (line.startsWith('#EXTINF:')) {
-                    const durationMatch = line.match(/#EXTINF:(\d+(\.\d+)?)/);
-                    if (durationMatch) {
-                        currentSegmentDuration = parseFloat(durationMatch[1]);
-                        totalOriginalDuration += currentSegmentDuration;
-
-                        if (!skipContent) {
-                            totalFilteredDuration += currentSegmentDuration;
-                            filteredLines.push(line);
-                        }
-                    } else {
-                        if (!skipContent) {
-                            filteredLines.push(line);
-                        }
-                    }
-                    continue;
-                }
-                // 片段 URL 行
-                if (line.length > 0 && !line.startsWith('#')) {
-                    if (!skipContent) {
-                        filteredLines.push(line);
-                    }
-                    afterSegmentUrl = true;
-                    currentSegmentDuration = 0;
-                    continue;
-                }
-
-                if (!skipContent || line.startsWith('#EXT')) {
-                    filteredLines.push(line);
-                }
-            }
-                
-            console.log('原始时长:', totalOriginalDuration, '过滤后时长:', totalFilteredDuration);
-            // 替换 M3U8 中的总时长标记（如果存在）
-            const filteredText = filteredLines.join('\n');
-            return filteredText.replace(/#EXT-X-TARGETDURATION:(\d+(\.\d+)?)/, (match, p1) => {
-                return `#EXT-X-TARGETDURATION:${p1}`;
-            });
+            let pattern = window.filterAdPattern;
+            const regex = new RegExp(pattern, 'g');
+            return m3u8Content.replace(regex, '');
         }
         
 

--- a/player.html
+++ b/player.html
@@ -331,6 +331,7 @@
             const urlParams = new URLSearchParams(window.location.search);
             const videoUrl = urlParams.get('url');
             const title = urlParams.get('title');
+            const sourceCode = urlParams.get('sourceCode');
             let index = parseInt(urlParams.get('index') || '0');
             const episodesList = urlParams.get('episodes'); // 新增：从URL获取集数信息
 
@@ -527,7 +528,7 @@
             // 配置HLS.js选项
             const hlsConfig = {
                 debug: false,
-                loader: adFilteringEnabled ? CustomHlsJsLoader : Hls.DefaultConfig.loader,
+                loader: (adFilteringEnabled && API_SITES[sourceCode].filterAd !== false) ? CustomHlsJsLoader : Hls.DefaultConfig.loader,
                 enableWorker: true,
                 lowLatencyMode: false,
                 backBufferLength: 90,

--- a/player.html
+++ b/player.html
@@ -622,7 +622,7 @@
                                     document.getElementById('error').style.display = 'none';
                                 }
                             });
-                            
+
                             hls.loadSource(video.src);
                             hls.attachMedia(video);
                             
@@ -688,32 +688,6 @@
                             // 监听级别加载事件
                             hls.on(Hls.Events.LEVEL_LOADED, function() {
                                 document.getElementById('loading').style.display = 'none';
-                            });
-
-                            // --- 体验加强版：黑屏快进跳广告 ---
-                            let tmp_time_add = 0.1;
-                            const tmp_max_buffer_length = hls.config.maxBufferLength;
-                            hls.on(Hls.Events.FRAG_PARSED, (event, data) => {
-                                if (data.frag.endList) {
-                                    const cur = hls.media.currentTime;
-                                    const dur = hls.media.duration || 0;
-                                    if (cur < dur) {
-                                        data.frag.endList = undefined;
-                                        // 根据 tmp_time_add 调整 buffer 长度
-                                        hls.config.maxBufferLength = tmp_time_add < 1
-                                            ? 2
-                                            : tmp_max_buffer_length;
-                                        // 重新加载并跳转
-                                        hls.loadSource(video.src);
-                                        hls.attachMedia(video);
-                                        hls.media.currentTime = cur + tmp_time_add;
-                                        // 切换下次跳转时长：0.1 ↔ 5
-                                        tmp_time_add = tmp_time_add < 1 ? 5 : 0.1;
-                                        player.video.play().catch(() => {});
-                                    } else {
-                                        player.video.pause();
-                                    }
-                                }
                             });
                         }
                     }
@@ -898,22 +872,70 @@
         // M3U8清单广告过滤函数
         function filterAdsFromM3U8(m3u8Content, strictMode = false) {
             if (!m3u8Content) return '';
-            
+
+            let skipContent = false;
+            let discontinuityCount = 0;
+            let currentSegmentDuration = 0;
+            let totalOriginalDuration = 0;
+            let totalFilteredDuration = 0;
+            let afterSegmentUrl = false
+                
             // 按行分割M3U8内容
             const lines = m3u8Content.split('\n');
             const filteredLines = [];
-            
-            for (let i = 0; i < lines.length; i++) {
-                const line = lines[i];
                 
-                // 只过滤#EXT-X-DISCONTINUITY标识
-                if (!line.includes('#EXT-X-DISCONTINUITY')) {
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i].trim();
+
+                if (line.includes('#EXT-X-DISCONTINUITY')) {
+                    discontinuityCount++;
+                    if (afterSegmentUrl) {
+                        // 在视频 url 前可能会出现 DISCONTINUITY 的情况，忽略
+                        skipContent = !skipContent;
+                    }
+                    continue;
+                }
+
+                if (line.startsWith('#EXTINF:')) {
+                    const durationMatch = line.match(/#EXTINF:(\d+(\.\d+)?)/);
+                    if (durationMatch) {
+                        currentSegmentDuration = parseFloat(durationMatch[1]);
+                        totalOriginalDuration += currentSegmentDuration;
+
+                        if (!skipContent) {
+                            totalFilteredDuration += currentSegmentDuration;
+                            filteredLines.push(line);
+                        }
+                    } else {
+                        if (!skipContent) {
+                            filteredLines.push(line);
+                        }
+                    }
+                    continue;
+                }
+                // 片段 URL 行
+                if (line.length > 0 && !line.startsWith('#')) {
+                    if (!skipContent) {
+                        filteredLines.push(line);
+                    }
+                    afterSegmentUrl = true;
+                    currentSegmentDuration = 0;
+                    continue;
+                }
+
+                if (!skipContent || line.startsWith('#EXT')) {
                     filteredLines.push(line);
                 }
             }
-            
-            return filteredLines.join('\n');
+                
+            console.log('原始时长:', totalOriginalDuration, '过滤后时长:', totalFilteredDuration);
+            // 替换 M3U8 中的总时长标记（如果存在）
+            const filteredText = filteredLines.join('\n');
+            return filteredText.replace(/#EXT-X-TARGETDURATION:(\d+(\.\d+)?)/, (match, p1) => {
+                return `#EXT-X-TARGETDURATION:${p1}`;
+            });
         }
+        
 
         // 显示错误
         function showError(message) {

--- a/player.html
+++ b/player.html
@@ -275,8 +275,8 @@
         // 保存原始 js‑sha256 实现，避免被 password.js 覆盖
         window._jsSha256 = window.sha256;
     </script>
-    <script src="https://s4.zstatic.net/ajax/libs/hls.js/1.5.6/hls.min.js" integrity="sha256-X1GmLMzVcTBRiGjEau+gxGpjRK96atNczcLBg5w6hKA=" crossorigin="anonymous"></script>
-    <script src="https://s4.zstatic.net/ajax/libs/dplayer/1.26.0/DPlayer.min.js" integrity="sha256-OJg03lDZP0NAcl3waC9OT5jEa8XZ8SM2n081Ik953o4=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1.6.2/dist/hls.min.js" crossorigin="anonymous"></script>
+    <script src="https://s4.zstatic.net/ajax/libs/dplayer/1.27.1/DPlayer.min.js" crossorigin="anonymous"></script>
     <script src="js/config.js"></script>
     <script src="js/password.js"></script>
 
@@ -331,7 +331,7 @@
             const urlParams = new URLSearchParams(window.location.search);
             const videoUrl = urlParams.get('url');
             const title = urlParams.get('title');
-            const sourceCode = urlParams.get('sourceCode');
+            const sourceCode = urlParams.get('source_code');
             let index = parseInt(urlParams.get('index') || '0');
             const episodesList = urlParams.get('episodes'); // 新增：从URL获取集数信息
 
@@ -398,7 +398,7 @@
 
             // 初始化播放器
             if (videoUrl) {
-                initPlayer(videoUrl);
+                initPlayer(videoUrl, sourceCode);
                 
                 // 尝试从URL参数中恢复播放位置
                 const position = urlParams.get('position');
@@ -522,7 +522,7 @@
         }
 
         // 初始化播放器
-        function initPlayer(videoUrl) {
+        function initPlayer(videoUrl, sourceCode) {
             if (!videoUrl) return;
 
             // 配置HLS.js选项
@@ -692,7 +692,7 @@
                             });
                         }
                     }
-                }
+            }
             });
             // 全屏模式下锁定横屏
             dp.on('fullscreen', () => {
@@ -1054,6 +1054,7 @@
             // 获取当前URL参数，保留source参数
             const urlParams = new URLSearchParams(window.location.search);
             const sourceName = urlParams.get('source') || '';
+            const sourceCode = urlParams.get('source_code') || '';
             
             // 更新URL，不刷新页面，保留source参数
             const newUrl = new URL(window.location.href);
@@ -1061,6 +1062,9 @@
             newUrl.searchParams.set('url', url);
             if (sourceName) {
                 newUrl.searchParams.set('source', sourceName);
+            }
+            if (sourceCode) {
+                newUrl.searchParams.set('source_code', sourceCode);
             }
             window.history.pushState({}, '', newUrl);
             
@@ -1078,16 +1082,16 @@
                         playPromise.catch(error => {
                             console.warn('播放失败，尝试重新初始化:', error);
                             // 如果切换视频失败，重新初始化播放器
-                            initPlayer(url);
+                            initPlayer(url, sourceCode);
                         });
                     }
                 } catch (e) {
                     console.error('切换视频出错，尝试重新初始化:', e);
                     // 如果出错，重新初始化播放器
-                    initPlayer(url);
+                    initPlayer(url, sourceCode);
                 }
             } else {
-                initPlayer(url);
+                initPlayer(url, sourceCode);
             }
             
             // 更新UI
@@ -1227,6 +1231,7 @@
             // 尝试从URL中获取参数
             const urlParams = new URLSearchParams(window.location.search);
             const sourceName = urlParams.get('source') || '';
+            const sourceCode = urlParams.get('source_code') || '';
 
             // 获取当前播放进度
             let currentPosition = 0;
@@ -1241,7 +1246,7 @@
             const videoInfo = {
                 title: currentVideoTitle,
                 // 创建基础URL，使用标题作为唯一标识符
-                url: `player.html?title=${encodeURIComponent(currentVideoTitle)}&source=${encodeURIComponent(sourceName)}`,
+                url: `player.html?title=${encodeURIComponent(currentVideoTitle)}&source=${encodeURIComponent(sourceName)}&source_code=${encodeURIComponent(sourceCode)}`,
                 episodeIndex: currentEpisodeIndex,
                 sourceName: sourceName,
                 timestamp: Date.now(),


### PR DESCRIPTION
1. 广告过滤应过滤 #EXT-X-DISCONTINUITY 之间的行，原逻辑只删除了 #EXT-X-DISCONTINUITY 行，未起效
2. 删除跳过最后一个分片的逻辑：
- 由于已存在去广告逻辑，最后一个分片为合法视频分片，不应跳过
- 重新加载视频并移动进度条会设置 isUserSeeking 标识，导致自动播放下一集失效
- （可能）由于存在去广告逻辑，可播放（去广告后）的时长与 hls.media.currentTime 可能会出现不一致，导致跳转失败

经简单测试，可解决 #197 
