### PR TITLE
修复反向代理后的客户端请求

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -122,6 +122,13 @@ function isValidUrl(urlString) {
   }
 }
 
+// 修复反向代理处理过的路径
+app.use('/proxy', (req, res, next) => {
+  const targetUrl = req.url.replace(/^\//, '').replace(/(https?:)\/([^/])/, '$1//$2');
+  req.url = '/' + encodeURIComponent(targetUrl);
+  next();
+});
+
 // 代理路由
 app.get('/proxy/:encodedUrl', async (req, res) => {
   try {


### PR DESCRIPTION
客户端请求经过反向代理后，/proxy/请求会被转义和修改，导致express无法识别，主要反映在以下两点：

1.  目标API地址中的 http:// https:// 会变成单斜杠；
2.  转义后无法进入 '/proxy/:encodedUrl' 路由。

考虑到部分用户无法配置反向代理服务器，建议在源代码中对这种情况进行修复。