### PR TITLE
sync-upstream.yml

### DIFF
--- a/sync-upstream.yml
+++ b/sync-upstream.yml
@@ -1,0 +1,23 @@
+name: LibreTV Sync Upstream  
+
+on:  
+  schedule:  
+    - cron: "0 3 * * *"  
+  workflow_dispatch:  
+
+permissions:  
+  contents: write  
+
+jobs:  
+  sync:  
+    runs-on: ubuntu-latest  
+    steps:  
+      - uses: actions/checkout@v4  
+        with:  
+          fetch-depth: 0  
+      - name: Add upstream  
+        run: |  
+          git remote add upstream https://github.com/LibreSpark/LibreTV.git  
+          git fetch upstream  
+          git merge upstream/main --allow-unrelated-histories -m "🔄 Sync from upstream"  
+          git push origin main


### PR DESCRIPTION
name: LibreTV Sync Upstream  

on:  
  schedule:  
    - cron: "0 3 * * *"  
  workflow_dispatch:  

permissions:  
  contents: write  

jobs:  
  sync:  
    runs-on: ubuntu-latest  
    steps:  
      - uses: actions/checkout@v4  
        with:  
          fetch-depth: 0  
      - name: Add upstream  
        run: |  
          git remote add upstream https://github.com/LibreSpark/LibreTV.git  
          git fetch upstream  
          git merge upstream/main --allow-unrelated-histories -m "🔄 Sync from upstream"  
          git push origin main